### PR TITLE
pom.xml: Depend on JAX-WS API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,12 @@
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
             <version>2.3.5</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
The JAX-WS runtime is only used for tests and the main java. The rest of the API is automatically generated and independent of the exact JAX-WS runtime used.

see also  https://github.com/B3Partners/brmo/pull/1323