### PR TITLE
Revert "Bump org.apache.maven.plugins:maven-scm-publish-plugin from 3.2.1 to 3.3.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Reverts B3Partners/kadaster-gds2#331

see https://github.com/B3Partners/jdbc-util/pull/630